### PR TITLE
Mogut el dia de modificació fins el diumenge anterior

### DIFF
--- a/constants/calendar.ts
+++ b/constants/calendar.ts
@@ -9,4 +9,4 @@ export const CALENDAR_NUM_WEEKS = 12
  * 5: Friday
  * 6: Saturday
  */
-export const LIMIT_DAY = 4 // Thursday 00:00
+export const LIMIT_DAY = 6 // Thursday 00:00


### PR DESCRIPTION
Per a evitar que ens indiquin canvis a traves de whatsapp abans de la setmana de cistelles, permetrem modificar fins diumenge la comanda de la setmana seguent.